### PR TITLE
Feature/support venvs

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Publish Python distributions to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.7
@@ -21,13 +21,13 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       continue-on-error: true
       with:
         password: ${{ secrets.TEST_PYPI_PASSWORD }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10.6]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with codecs_open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pywinsandbox',
-      version='1.2.0',
+      version='1.3.0',
       description=u"Python Utilities for Windows Sandbox",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/winsandbox/folder_mapper.py
+++ b/winsandbox/folder_mapper.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+import site
 
 
 class FolderMapper:
@@ -24,7 +25,19 @@ class PythonMapper:
     """
 
     def path(self):
-        return pathlib.Path(sys.executable).parent
+        return pathlib.Path(sys.prefix)
+
+    def read_only(self):
+        return True
+
+
+class PythonUserSitePackagesMapper:
+    """
+    Maps the current Python installation's user site packages to the new sandbox.
+    """
+
+    def path(self):
+        return pathlib.Path(site.getusersitepackages())
 
     def read_only(self):
         return True

--- a/winsandbox/launch.py
+++ b/winsandbox/launch.py
@@ -1,5 +1,5 @@
 from .utils.sandbox_feature_state import verify_sandbox_feature_is_enabled
-from .folder_mapper import PythonMapper
+from .folder_mapper import PythonMapper, PythonUserSitePackagesMapper
 from .sandbox import OnlineSandbox, OfflineSandbox
 from .config import SandboxConfig
 import sys
@@ -8,7 +8,7 @@ import sys
 if 'pytest' not in sys.modules:
     verify_sandbox_feature_is_enabled()
 
-_DEFAULT_FOLDER_MAPPERS = [PythonMapper()]
+_DEFAULT_FOLDER_MAPPERS = [PythonMapper(), PythonUserSitePackagesMapper()]
 
 
 def new_sandbox(folder_mappers=None, networking=True, logon_script="", virtual_gpu=True):

--- a/winsandbox/utils/venv.py
+++ b/winsandbox/utils/venv.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def is_inside_venv():
+    return sys.prefix != sys.base_prefix


### PR DESCRIPTION
- Supporting virtual-environment by mapping the base prefix directory as well as the prefix directory and creating a symlink (to allow the original python directory to be accessible by the venv). 
- Also supporting the case where some of the packages were installed in a user site packages directory instead of in the global site packages directory

This should close the 2 issues mentioned in #14 